### PR TITLE
fix: add bfloat16 to allowed dtypes

### DIFF
--- a/ema_pytorch/ema_pytorch.py
+++ b/ema_pytorch/ema_pytorch.py
@@ -105,12 +105,12 @@ class EMA(Module):
         self.parameter_names = {
             name
             for name, param in self.ema_model.named_parameters()
-            if param.dtype in [torch.float, torch.float16, torch.bfloat16]
+            if torch.is_floating_point(param) or torch.is_complex(param)
         }
         self.buffer_names = {
             name
             for name, buffer in self.ema_model.named_buffers()
-            if buffer.dtype in [torch.float, torch.float16, torch.bfloat16]
+            if torch.is_floating_point(buffer) or torch.is_complex(buffer)
         }
 
         # tensor update functions

--- a/ema_pytorch/post_hoc_ema.py
+++ b/ema_pytorch/post_hoc_ema.py
@@ -105,12 +105,12 @@ class KarrasEMA(Module):
         self.parameter_names = {
             name
             for name, param in self.ema_model.named_parameters()
-            if param.dtype in [torch.float, torch.float16, torch.bfloat16]
+            if torch.is_floating_point(param) or torch.is_complex(param)
         }
         self.buffer_names = {
             name
             for name, buffer in self.ema_model.named_buffers()
-            if buffer.dtype in [torch.float, torch.float16, torch.bfloat16]
+            if torch.is_floating_point(buffer) or torch.is_complex(buffer)
         }
 
         # tensor update functions

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,25 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
-  name = 'ema-pytorch',
-  packages = find_packages(exclude=[]),
-  version = '0.4.2',
-  license='MIT',
-  description = 'Easy way to keep track of exponential moving average version of your pytorch module',
-  author = 'Phil Wang',
-  author_email = 'lucidrains@gmail.com',
-  long_description_content_type = 'text/markdown',
-  url = 'https://github.com/lucidrains/ema-pytorch',
-  keywords = [
-    'artificial intelligence',
-    'deep learning',
-    'exponential moving average'
-  ],
-  install_requires=[
-    'beartype',
-    'torch>=1.6',
-  ],
-  classifiers=[
-    'Development Status :: 4 - Beta',
-    'Intended Audience :: Developers',
-    'Topic :: Scientific/Engineering :: Artificial Intelligence',
-    'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 3.6',
-  ],
+    name="ema-pytorch",
+    packages=find_packages(exclude=[]),
+    version="0.4.3",
+    license="MIT",
+    description="Easy way to keep track of exponential moving average version of your pytorch module",
+    author="Phil Wang",
+    author_email="lucidrains@gmail.com",
+    long_description_content_type="text/markdown",
+    url="https://github.com/lucidrains/ema-pytorch",
+    keywords=["artificial intelligence", "deep learning", "exponential moving average"],
+    install_requires=[
+        "beartype",
+        "torch>=1.6",
+    ],
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3.6",
+    ],
 )


### PR DESCRIPTION
This was very painful to debug. Maybe it shouldn't have been but this was unexpected for me.

Sorry about all the formatting fixes. It's black. The change is just adding "torch.bfloat16" to the device types. Also bumped the version