### PR TITLE
Tensor -> tensor

### DIFF
--- a/ema_pytorch/post_hoc_ema.py
+++ b/ema_pytorch/post_hoc_ema.py
@@ -362,11 +362,11 @@ class PostHocEMA(Module):
 
         # line up with Algorithm 3
 
-        gamma_i = Tensor(gammas, device = device)
-        t_i = Tensor(timesteps, device = device)
+        gamma_i = torch.tensor(gammas, device = device)
+        t_i = torch.tensor(timesteps, device = device)
 
-        gamma_r = Tensor([gamma], device = device)
-        t_r = Tensor([step], device = device)
+        gamma_r = torch.tensor([gamma], device = device)
+        t_r = torch.tensor([step], device = device)
 
         # solve for weights for combining all checkpoints into synthesized, using least squares as in paper
 


### PR DESCRIPTION
`Tensor` constructor annoyingly crashes if `device` is not `cpu`. Eg:

```python
In [1]: import torch

In [2]: a = torch.Tensor([1, 2, 3], device="cuda")
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In[2], line 1
----> 1 a = torch.Tensor([1, 2, 3], device="cuda")

RuntimeError: legacy constructor expects device type: cpu but device type: cuda was passed

In [3]: b = torch.tensor([1, 2, 3], device="cuda")

In [4]:
```