### PR TITLE
Alternative way to set requires_grad to False

### DIFF
--- a/ema_pytorch/ema_pytorch.py
+++ b/ema_pytorch/ema_pytorch.py
@@ -90,7 +90,8 @@ class EMA(Module):
                 print('Your model was not copyable. Please make sure you are not using any LazyLinear')
                 exit()
 
-        self.ema_model.requires_grad_(False)
+        for p in self.ema_model.parameters():
+            p.detach_()
 
         # parameter and buffer names
 


### PR DESCRIPTION
Suppose we want to use this with a TorchScript Module, i.e. [model](https://github.com/lucidrains/ema-pytorch/blob/b53bbd7efb8045a1cfdc5fb1da7f0b3873fb71c2/ema_pytorch/ema_pytorch.py#L53) is something obtained from `torch.jit.script`. Then setting grads to `False` using `requires_grad_` will fail, because it is not supported for a TorchScript module. 

This PR uses an alternative way to set the grads to `False`. 