### PR TITLE
fix FutureWarning with `torch.load`

### DIFF
--- a/ema_pytorch/post_hoc_ema.py
+++ b/ema_pytorch/post_hoc_ema.py
@@ -385,7 +385,7 @@ class PostHocEMA(Module):
 
             # load checkpoint into a temporary ema model
 
-            ckpt_state_dict = torch.load(str(checkpoint))
+            ckpt_state_dict = torch.load(str(checkpoint), weights_only=True)
             tmp_ema_model.load_state_dict(ckpt_state_dict)
 
             # add weighted checkpoint to synthesized


### PR DESCRIPTION
This pull request addresses the FutureWarning issue described in [issue #26](https://github.com/lucidrains/ema-pytorch/issues/26).

- Updated `torch.load` to use `weights_only=True` to avoid potential security risks and to comply with future PyTorch updates.
- Tested with PyTorch version 2.4.0.
