### PR TITLE
Ensure `current_decay` is on the correct device in `update_moving_average`

### DIFF
--- a/ema_pytorch/post_hoc_ema.py
+++ b/ema_pytorch/post_hoc_ema.py
@@ -219,7 +219,7 @@ class KarrasEMA(Module):
                 copy(ma_params.data, current_params.data)
                 continue
 
-            lerp(ma_params.data, current_params.data, 1. - current_decay)
+            lerp(ma_params.data, current_params.data, 1. - current_decay.to(current_params.device))
 
         for (name, current_buffer), (_, ma_buffer) in zip(self.get_buffers_iter(current_model), self.get_buffers_iter(ma_model)):
             if name in self.ignore_names:


### PR DESCRIPTION
In `KarrasEMA`, if both `current_model` and `ma_model` are on the CUDA device, `update_moving_average()` could fail because `self.beta` remains on the CPU.

My changes might not be very elegant. Please take a look and find for a more appropriate solution.